### PR TITLE
Fix rhythm circle removal loop skipping elements

### DIFF
--- a/Assets/Scripts/RhythmGameController.cs
+++ b/Assets/Scripts/RhythmGameController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class RhythmGameController : MonoBehaviour
 {
-    public GameObject circlePrefab; // Prefab del cÌrculo que aparecer· en la lÌnea de ritmo
+    public GameObject circlePrefab; // Prefab del c√≠rculo que aparecer√° en la l√≠nea de ritmo
     public GameObject circleLPrefab;
     public GameObject circleWPrefab;
     public float spawnInterval = 1.0f;
@@ -35,7 +35,7 @@ public class RhythmGameController : MonoBehaviour
         shootWave = GameObject.Find("ShotWave").GetComponent<ShootWave>();
         center = GameObject.Find("center");
 
-        // Generar un cÌrculo cada cierto intervalo de tiempo
+        // Generar un c√≠rculo cada cierto intervalo de tiempo
         StartCoroutine(SpawnCircleRoutine());
         StartCoroutine(SpawnCircleLRoutine());
         StartCoroutine(SpawnCircleWRoutine());
@@ -45,14 +45,14 @@ public class RhythmGameController : MonoBehaviour
     {
         while (true)
         {
-            // Crear un nuevo cÌrculo (nota) y agregarlo a la lista de cÌrculos
+            // Crear un nuevo c√≠rculo (nota) y agregarlo a la lista de c√≠rculos
             GameObject newCircle = Instantiate(circlePrefab, transform);
             RectTransform RTnewCircle = newCircle.GetComponent<RectTransform>();
-            RTnewCircle.anchoredPosition = new Vector2(-450f, 0f); // PosiciÛn inicial
+            RTnewCircle.anchoredPosition = new Vector2(-450f, 0f); // Posici√≥n inicial
 
-            circles.Add(newCircle); // Agregar el cÌrculo a la lista
+            circles.Add(newCircle); // Agregar el c√≠rculo a la lista
 
-            yield return new WaitForSeconds(spawnInterval); // Esperar antes de crear el siguiente cÌrculo
+            yield return new WaitForSeconds(spawnInterval); // Esperar antes de crear el siguiente c√≠rculo
             //canShoot = true;
         }
     }
@@ -60,14 +60,14 @@ public class RhythmGameController : MonoBehaviour
     {
         while (true)
         {
-            // Crear un nuevo cÌrculo (nota) y agregarlo a la lista de cÌrculos
+            // Crear un nuevo c√≠rculo (nota) y agregarlo a la lista de c√≠rculos
             GameObject newCircleL = Instantiate(circleLPrefab, transform);
             RectTransform RTnewCircleL = newCircleL.GetComponent<RectTransform>();
-            RTnewCircleL.anchoredPosition = new Vector2(-450f, 0f); // PosiciÛn inicial
+            RTnewCircleL.anchoredPosition = new Vector2(-450f, 0f); // Posici√≥n inicial
 
-            circlesL.Add(newCircleL); // Agregar el cÌrculo a la lista
+            circlesL.Add(newCircleL); // Agregar el c√≠rculo a la lista
 
-            yield return new WaitForSeconds(spawnIntervalL); // Esperar antes de crear el siguiente cÌrculo
+            yield return new WaitForSeconds(spawnIntervalL); // Esperar antes de crear el siguiente c√≠rculo
             //canShoot = true;
         }
     }
@@ -75,32 +75,32 @@ public class RhythmGameController : MonoBehaviour
     {
         while (true)
         {
-            // Crear un nuevo cÌrculo (nota) y agregarlo a la lista de cÌrculos
+            // Crear un nuevo c√≠rculo (nota) y agregarlo a la lista de c√≠rculos
             GameObject newCircleW = Instantiate(circleWPrefab, transform);
             RectTransform RTnewCircleW = newCircleW.GetComponent<RectTransform>();
-            RTnewCircleW.anchoredPosition = new Vector2(-450f, 0f); // PosiciÛn inicial
+            RTnewCircleW.anchoredPosition = new Vector2(-450f, 0f); // Posici√≥n inicial
 
-            circlesW.Add(newCircleW); // Agregar el cÌrculo a la lista
+            circlesW.Add(newCircleW); // Agregar el c√≠rculo a la lista
 
-            yield return new WaitForSeconds(spawnIntervalW); // Esperar antes de crear el siguiente cÌrculo
+            yield return new WaitForSeconds(spawnIntervalW); // Esperar antes de crear el siguiente c√≠rculo
             //canShoot = true;
         }
     }
 
     void Update()
     {
-        // Verificar si se pulsa la tecla Espacio y si hay cÌrculos en la lista
+        // Verificar si se pulsa la tecla Espacio y si hay c√≠rculos en la lista
         if (Input.GetKeyDown(KeyCode.Space) && !penaltyActive)
         {
             penalize = true;
-            // Verificar cada cÌrculo en la lista
+            // Verificar cada c√≠rculo en la lista
             for (int i = circles.Count - 1; i >= 0; i--)
             {
                 GameObject circle = circles[i];
                 RectTransform RTcircle = circle.GetComponent<RectTransform>();
                 //Debug.Log($"Touched: {centerCollider.IsTouched()}, X Position: {RTcircle.anchoredPosition.x}");
 
-                // Verificar si este cÌrculo est· en contacto con el BoxCollider2D "centerCollider"
+                // Verificar si este c√≠rculo est√° en contacto con el BoxCollider2D "centerCollider"
 
                 if (RTcircle.anchoredPosition.x > -30f && RTcircle.anchoredPosition.x < 30f)
                 {
@@ -108,25 +108,23 @@ public class RhythmGameController : MonoBehaviour
                     //canShoot = false;
                     Destroy(circle);
                     circles.RemoveAt(i);
-                    i--;
                     penalize = false;
                 }
             }
-            // Verificar cada cÌrculo en la lista
+            // Verificar cada c√≠rculo en la lista
             for (int i = circlesL.Count - 1; i >= 0; i--)
             {
                 GameObject circleL = circlesL[i];
                 RectTransform RTcircleL = circleL.GetComponent<RectTransform>();
                 //Debug.Log($"Touched: {centerCollider.IsTouched()}, X Position: {RTcircle.anchoredPosition.x}");
 
-                // Verificar si este cÌrculo est· en contacto con el BoxCollider2D "centerCollider"
+                // Verificar si este c√≠rculo est√° en contacto con el BoxCollider2D "centerCollider"
                 if (RTcircleL.anchoredPosition.x > -30f && RTcircleL.anchoredPosition.x < 30f)
                 {
                     shootBeam.shootBeam();
                     //canShoot = false;
                     Destroy(circleL);
                     circlesL.RemoveAt(i);
-                    i--;
                     penalize = false;
                 }
             }
@@ -136,14 +134,13 @@ public class RhythmGameController : MonoBehaviour
                 RectTransform RTcircleW = circleW.GetComponent<RectTransform>();
                 //Debug.Log($"Touched: {centerCollider.IsTouched()}, X Position: {RTcircle.anchoredPosition.x}");
 
-                // Verificar si este cÌrculo est· en contacto con el BoxCollider2D "centerCollider"
+                // Verificar si este c√≠rculo est√° en contacto con el BoxCollider2D "centerCollider"
                 if (RTcircleW.anchoredPosition.x > -30f && RTcircleW.anchoredPosition.x < 30f)
                 {
                     shootWave.waveGrowth();
                     //canShoot = false;
                     Destroy(circleW);
                     circlesW.RemoveAt(i);
-                    i--;
                     penalize = false;
                 }
             }
@@ -154,21 +151,21 @@ public class RhythmGameController : MonoBehaviour
             StartCoroutine(TakePenalty());            
         }
 
-        // Mover y verificar cada cÌrculo en la lista
+        // Mover y verificar cada c√≠rculo en la lista
         for (int i = 0; i < circles.Count; i++)
         {
             GameObject circle = circles[i];
             RectTransform RTcircle = circle.GetComponent<RectTransform>();
 
-            // Mover el cÌrculo hacia la derecha
+            // Mover el c√≠rculo hacia la derecha
             RTcircle.anchoredPosition += Vector2.right * moveSpeed * Time.deltaTime;
 
-            // Verificar si el cÌrculo debe ser destruido
+            // Verificar si el c√≠rculo debe ser destruido
             if (RTcircle.anchoredPosition.x >= destroyPositionX)
             {
-                Destroy(circle); // Destruir el GameObject del cÌrculo
-                circles.RemoveAt(i); // Eliminar el cÌrculo de la lista
-                i--; // Decrementar el Ìndice para evitar omitir el siguiente cÌrculo
+                Destroy(circle); // Destruir el GameObject del c√≠rculo
+                circles.RemoveAt(i); // Eliminar el c√≠rculo de la lista
+                i--; // Decrementar el √≠ndice para evitar omitir el siguiente c√≠rculo
             }
         }        
         
@@ -178,15 +175,15 @@ public class RhythmGameController : MonoBehaviour
             if (circleL != null)
             {
                 RectTransform RTcircleL = circleL.GetComponent<RectTransform>();
-                // Mover el cÌrculo hacia la derecha
+                // Mover el c√≠rculo hacia la derecha
                 RTcircleL.anchoredPosition += Vector2.right * moveSpeedL * Time.deltaTime;
 
-                // Verificar si el cÌrculo debe ser destruido
+                // Verificar si el c√≠rculo debe ser destruido
                 if (RTcircleL.anchoredPosition.x >= destroyPositionX)
                 {
-                    Destroy(circleL); // Destruir el GameObject del cÌrculo
-                    circlesL.RemoveAt(i); // Eliminar el cÌrculo de la lista
-                    i--; // Decrementar el Ìndice para evitar omitir el siguiente cÌrculo
+                    Destroy(circleL); // Destruir el GameObject del c√≠rculo
+                    circlesL.RemoveAt(i); // Eliminar el c√≠rculo de la lista
+                    i--; // Decrementar el √≠ndice para evitar omitir el siguiente c√≠rculo
                 }
             }
         }
@@ -196,15 +193,15 @@ public class RhythmGameController : MonoBehaviour
             if (circleW != null)
             {
                 RectTransform RTcircleW = circleW.GetComponent<RectTransform>();
-                // Mover el cÌrculo hacia la derecha
+                // Mover el c√≠rculo hacia la derecha
                 RTcircleW.anchoredPosition += Vector2.right * moveSpeedW * Time.deltaTime;
 
-                // Verificar si el cÌrculo debe ser destruido
+                // Verificar si el c√≠rculo debe ser destruido
                 if (RTcircleW.anchoredPosition.x >= destroyPositionX)
                 {
-                    Destroy(circleW); // Destruir el GameObject del cÌrculo
-                    circlesW.RemoveAt(i); // Eliminar el cÌrculo de la lista
-                    i--; // Decrementar el Ìndice para evitar omitir el siguiente cÌrculo
+                    Destroy(circleW); // Destruir el GameObject del c√≠rculo
+                    circlesW.RemoveAt(i); // Eliminar el c√≠rculo de la lista
+                    i--; // Decrementar el √≠ndice para evitar omitir el siguiente c√≠rculo
                 }
             }
         }
@@ -216,7 +213,7 @@ public class RhythmGameController : MonoBehaviour
         center.SetActive(false);
         yield return new WaitForSeconds(penaltyTime);
         center.SetActive(true);
-        penaltyActive = false; // Restablecer la bandera de penalizaciÛn al finalizar
+        penaltyActive = false; // Restablecer la bandera de penalizaci√≥n al finalizar
         penalize = false;
     }
 }


### PR DESCRIPTION
## Summary
- avoid skipping rhythm circles when removing by not decrementing loop index manually

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974510a328832ab7977ffe2ff12d43